### PR TITLE
Fix build on !Windows

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 framework = arduino
 board = d1_mini
 platform = espressif8266
-extra_scripts = pre:rename_firmware.py, pre:copy_base.py, pre:src\base\data\prepare_webfiles.py
+extra_scripts = pre:rename_firmware.py, pre:copy_base.py, pre:src/base/data/prepare_webfiles.py
 build_flags = -D MODEL=WirelessPalaControl
 upload_speed = 921600
 monitor_speed = 38400

--- a/src/Main.h
+++ b/src/Main.h
@@ -1,7 +1,7 @@
 #ifndef Main_h
 #define Main_h
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // DomoChip Informations
 // Configuration Web Pages :

--- a/src/WirelessPalaControl.h
+++ b/src/WirelessPalaControl.h
@@ -2,18 +2,18 @@
 #define WirelessPalaControl_h
 
 #include "Main.h"
-#include "base\Utils.h"
-#include "base\MQTTMan.h"
-#include "base\Application.h"
+#include "base/Utils.h"
+#include "base/MQTTMan.h"
+#include "base/Application.h"
 
 const char appDataPredefPassword[] PROGMEM = "ewcXoCt4HHjZUvY1";
 
-#include "data\status1.html.gz.h"
-#include "data\config1.html.gz.h"
+#include "data/status1.html.gz.h"
+#include "data/config1.html.gz.h"
 
 #include <PolledTimeout.h>
 #include <Palazzetti.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 
 class WebPalaControl : public Application
 {

--- a/src/base/Application.h
+++ b/src/base/Application.h
@@ -1,7 +1,7 @@
 #ifndef Application_h
 #define Application_h
 
-#include "..\Main.h"
+#include "../Main.h"
 #include <LittleFS.h>
 #include <ESP8266WebServer.h>
 #include <ArduinoJson.h>

--- a/src/base/Core.cpp
+++ b/src/base/Core.cpp
@@ -1,13 +1,13 @@
 #include "Core.h"
 #include <EEPROM.h>
 // #include <SPIFFSEditor.h>
-#include "..\Main.h" //for VERSION define
+#include "../Main.h" //for VERSION define
 #include "Version.h" //for BASE_VERSION define
 
-#include "data\index.html.gz.h"
-#include "data\pure-min.css.gz.h"
-#include "data\side-menu.css.gz.h"
-#include "data\side-menu.js.gz.h"
+#include "data/index.html.gz.h"
+#include "data/pure-min.css.gz.h"
+#include "data/side-menu.css.gz.h"
+#include "data/side-menu.js.gz.h"
 
 void Core::setConfigDefaultValues(){};
 void Core::parseConfigJSON(DynamicJsonDocument &doc){};

--- a/src/base/Core.h
+++ b/src/base/Core.h
@@ -1,16 +1,16 @@
 #ifndef Core_h
 #define Core_h
 
-#include "..\Main.h"
+#include "../Main.h"
 #include "Application.h"
 #ifdef ESP32
 #include <Update.h>
 #endif
 
-#include "data\status0.html.gz.h"
-#include "data\config0.html.gz.h"
-#include "data\fw0.html.gz.h"
-#include "data\discover0.html.gz.h"
+#include "data/status0.html.gz.h"
+#include "data/config0.html.gz.h"
+#include "data/fw0.html.gz.h"
+#include "data/discover0.html.gz.h"
 
 class Core : public Application
 {

--- a/src/base/MQTTMan.h
+++ b/src/base/MQTTMan.h
@@ -1,7 +1,7 @@
 #ifndef MQTTMan_h
 #define MQTTMan_h
 
-#include "..\Main.h"
+#include "../Main.h"
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
 #else

--- a/src/base/Main.cpp
+++ b/src/base/Main.cpp
@@ -9,7 +9,7 @@
 #include <ESP8266WebServer.h>
 
 #include "Version.h"
-#include "..\Main.h"
+#include "../Main.h"
 #include "Application.h"
 #include "Core.h"
 #include "WifiMan.h"

--- a/src/base/Utils.h
+++ b/src/base/Utils.h
@@ -1,7 +1,7 @@
 #ifndef Utils_h
 #define Utils_h
 
-#include <arduino.h>
+#include <Arduino.h>
 
 class Utils
 {

--- a/src/base/WifiMan.h
+++ b/src/base/WifiMan.h
@@ -1,14 +1,14 @@
 #ifndef WifiMan_h
 #define WifiMan_h
 
-#include "..\Main.h"
+#include "../Main.h"
 #include "Application.h"
 
 #include <Ticker.h>
 #include <ESP8266mDNS.h>
 
-#include "data\statusw.html.gz.h"
-#include "data\configw.html.gz.h"
+#include "data/statusw.html.gz.h"
+#include "data/configw.html.gz.h"
 
 const char predefPassword[] PROGMEM = "ewcXoCt4HHjZUvY0";
 

--- a/src/base/data/prepare_webfiles.py
+++ b/src/base/data/prepare_webfiles.py
@@ -72,7 +72,7 @@ def convert_all_webfiles(dir):
 
 print('--- Converting web files ---')
 
-convert_all_webfiles(r'.\src\base\data')
-convert_all_webfiles(r'.\src\data')
+convert_all_webfiles(r'./src/base/data')
+convert_all_webfiles(r'./src/data')
 
 print('----------------------------')


### PR DESCRIPTION
- use / as path separator, not \
- use proper capitalization for include names

This makes it possible to build on Linux.