### PR TITLE
Fixed an issue where the WiFi reconnection routine

### DIFF
--- a/src/base/WifiMan.cpp
+++ b/src/base/WifiMan.cpp
@@ -61,7 +61,7 @@ void WifiMan::refreshWiFi()
         _refreshTicker.once(_refreshPeriod, [this]()
                             { _needRefreshWifi = true; });
 #else
-        _refreshTicker.once<typeof this>(_refreshPeriod * 1000, [](typeof this wifiMan)
+        _refreshTicker.once<typeof this>((float)_refreshPeriod, [](typeof this wifiMan)
                                          { wifiMan->_needRefreshWifi = true; }, this);
 #endif
       }


### PR DESCRIPTION
### Summary
Fixed an issue where the WiFi reconnection routine (`_refreshTicker.once()`) never triggered when the initial connection failed. The delay value was incorrectly multiplied by 1000, causing the timer to exceed the maximum supported duration by the Ticker library (~71 minutes). As a result, the reconnection callback was never executed.

### Root cause
In `WifiMan::refreshWiFi()`:
```cpp
_refreshTicker.once<typeof this>(_refreshPeriod * 1000, [](typeof this wifiMan)
    { wifiMan->_needRefreshWifi = true; }, this);
```

### Fix

Removed the unnecessary * 1000 multiplier:

### Impact

Restores proper WiFi auto-reconnect behavior when the ESP fails to connect on startup.

No side effects expected, as this change only corrects a timing unit mismatch.