### PR TITLE
Fix FAN3 & FAN4 not showing up in Home Assistant

### DIFF
--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -1022,7 +1022,7 @@ bool WPalaControl::mqttPublishHassDiscovery()
     uniqueId = uniqueIdPrefixStove + F("_FAN3");
 
     // entity type depends on Min and Max value of FAN3
-    topic = prepareEntityTopic(_ha.mqtt.hassDiscoveryPrefix, ifFan3SwitchEntity ? F("/switch/") : F("/number/"), uniqueId);
+    topic = prepareEntityTopic(_ha.mqtt.hassDiscoveryPrefix, ifFan3SwitchEntity ? F("switch") : F("number"), uniqueId);
 
     // prepare payload for Stove fan3 number
     jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
@@ -1067,7 +1067,7 @@ bool WPalaControl::mqttPublishHassDiscovery()
     uniqueId = uniqueIdPrefixStove + F("_FAN4");
 
     // entity type depends on Min and Max value of FAN4
-    topic = prepareEntityTopic(_ha.mqtt.hassDiscoveryPrefix, ifFan4SwitchEntity ? F("/switch/") : F("/number/"), uniqueId);
+    topic = prepareEntityTopic(_ha.mqtt.hassDiscoveryPrefix, ifFan4SwitchEntity ? F("switch") : F("number"), uniqueId);
 
     // prepare payload for Stove fan4 number
     jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'


### PR DESCRIPTION
Fix for issue #72, fan 3 & 4 were incorrectly reported in `/homeassistant//switch//` MQTT topic since `prepareEntityTopic` refactoring (note the two empty levels).

Fan 3 and fan 4 controls are correctly discovered and reported in home assistant:
<img width="321" height="522" alt="HA-Fan3   Fan4" src="https://github.com/user-attachments/assets/c8ed9a39-7cc6-4cf4-a0b9-262950ccc009" />
